### PR TITLE
Add the option of defining the server URL using a PHP constant

### DIFF
--- a/includes/template.php
+++ b/includes/template.php
@@ -6,10 +6,15 @@
 $frontity_server = 'http://localhost:3000';
 
 /**
- * Alternatively, you can use environment variables.
+ * Alternatively, you can use PHP constants or environment variables.
+ * 
+ * Note that, if the PHP constant exists, it would take precedence over
+ * the corresponding environment variable.
  */
-if (getenv("FRONTITY_SERVER")) {
-  $frontity_server = getenv("FRONTITY_SERVER");
+if ( defined( "FRONTITY_SERVER" ) ) {
+  $frontity_server = FRONTITY_SERVER;
+} else if ( getenv( "FRONTITY_SERVER" ) ) {
+  $frontity_server = getenv( "FRONTITY_SERVER" );
 }
 
 /***********************************************************************/


### PR DESCRIPTION
**What**

Just adds the possibility of defining the `FRONTITY_SERVER` PHP constant to define the URL where the Frontity server is running. For example, using this snippet:

```php
<?php

define("FRONTITY_SERVER", "https://my.frontity.site");
```

Closes #4 

**Why**

Required by some users (see #4).

**How**

Using the code added in #4 description.