### PR TITLE
Increase timeout of request to the Frontity server

### DIFF
--- a/frontity-embedded.php
+++ b/frontity-embedded.php
@@ -3,7 +3,7 @@
  * Plugin Name: Frontity Embedded Mode
  * Description: Replace the WordPress theme with an HTTP request to the Frontity server.
  * Plugin URI: https://github.com/frontity/frontity-embedded
- * Version: 1.1.0
+ * Version: 1.1.1
  * 
  * Author: Frontity
  * Author URI: https://frontity.org

--- a/includes/template.php
+++ b/includes/template.php
@@ -71,7 +71,8 @@ if ( is_preview() && is_user_logged_in() ) {
 }
 
 // Do the request to the Frontity server.
-$response = wp_remote_get( $url );
+$args = array( 'timeout' => 30 );
+$response = wp_remote_get( $url, $args );
 
 if ( !is_wp_error( $response ) ) {
   global $wp_query;


### PR DESCRIPTION

**What**

I have increased the timeout of the HTTP request that is done to the Frontity server.

**Why**

It seems like the default time for `wp_remote_get` is 5 seconds, which in this case may not be enough.

**How**

The `wp_remote_get` accepts a second argument with options and one of them is the `timeout`.
