### PR TITLE
Add `frontity_embedded` query to Frontity request

### DIFF
--- a/includes/template.php
+++ b/includes/template.php
@@ -28,6 +28,8 @@ if ( $_SERVER['REQUEST_URI'] === '/__webpack_hmr' ) {
 
 // Build the URL to do the request to the Frontity server.
 $url = $frontity_server . $_SERVER['REQUEST_URI'];
+// Add the `frontity_embedded` query.
+$url .= ( parse_url( $url, PHP_URL_QUERY ) ? '&' : '?' ) . 'frontity_embedded=true';
 
 // Add a token to the URL if the current page is a preview, but only if a user
 // is logged in.

--- a/includes/template.php
+++ b/includes/template.php
@@ -29,7 +29,7 @@ if ( $_SERVER['REQUEST_URI'] === '/__webpack_hmr' ) {
 // Build the URL to do the request to the Frontity server.
 $url = $frontity_server . $_SERVER['REQUEST_URI'];
 // Add the `frontity_embedded` query.
-$url .= ( parse_url( $url, PHP_URL_QUERY ) ? '&' : '?' ) . 'frontity_embedded=true';
+$url .= ( wp_parse_url( $url, PHP_URL_QUERY ) ? '&' : '?' ) . 'frontity_embedded=true';
 
 // Add a token to the URL if the current page is a preview, but only if a user
 // is logged in.


### PR DESCRIPTION
We added an `?frontity_embedded=true` query to the Frontity server request.

This means that from now on, Frontity packages can know if the render was requested by the Embedded mode by checking `state.frontity.options.embedded`, which is populated to `"true"` (string).

Co-authored-by: @DAreRodz 