### PR TITLE
Check if user can edit post before previewing it

### DIFF
--- a/includes/template.php
+++ b/includes/template.php
@@ -30,10 +30,10 @@ if ( $_SERVER['REQUEST_URI'] === '/__webpack_hmr' ) {
 $url = $frontity_server . $_SERVER['REQUEST_URI'];
 
 // Add a token to the URL if the current page is a preview, but only if a user
-// is logged in.
-if ( is_preview() && is_user_logged_in() ) {
-  // Get the entity ID.
-  $id = get_the_ID();
+// is logged in and can edit the post.
+$id = get_the_ID();
+
+if ( $id && is_preview() && is_user_logged_in() && current_user_can( 'edit_post', $id ) ) {
 
   // Define capabilites for an specific post or page. Since WordPress 5.5.1,
   // here we need to use only `post` related capabilities for both post and page


### PR DESCRIPTION
We have added @nicholasio suggestion to prevent users that can't edit a post from previewing the changes. It is a simple check using `current_user_can( 'edit_post' )`.

Co-authored-by: @DAreRodz 