### PR TITLE
Add UI for settings

### DIFF
--- a/frontity-embedded.php
+++ b/frontity-embedded.php
@@ -27,6 +27,9 @@ function frontity_embedded_loader() {
   // Load Capability_Tokens class.
   require_once plugin_dir_path( __FILE__ ) . '/includes/capability-tokens.php';
 
+  // Load the Admin page.
+  require_once plugin_dir_path( __FILE__ ) . '/includes/admin-page.php';
+
   // Start the Capability_Token class in each REST API request to see if it
   // contains a a token and it should be authenticated.
   add_action( 'rest_api_init', 'Capability_Tokens::setup' );
@@ -42,5 +45,22 @@ function frontity_embedded_loader() {
     20
   );
 }
-
 add_action( 'plugins_loaded', 'frontity_embedded_loader' );
+
+/**
+ * Add default settings upon activation.
+ */
+function frontity_embedded_activate() {
+  add_option( 'frontity_embedded_plugin_settings', array(
+    'frontity_server' => 'http://localhost:3000'
+  ) );
+}
+register_activation_hook( __FILE__, 'frontity_embedded_activate' );
+
+/**
+ * Delete settings on uninstall.
+ */
+function frontity_embedded_uninstall() {
+  delete_option( 'frontity_embedded_plugin_settings' );
+}
+register_uninstall_hook( __FILE__, 'frontity_embedded_uninstall' );

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -30,7 +30,9 @@ function frontity_embedded_register_settings() {
   register_setting(
     'frontity_embedded_plugin_settings',
     'frontity_embedded_plugin_settings',
-    'frontity_embedded_validate_settings'
+    array(
+        'sanitize_callback' => 'frontity_embedded_validate_settings',
+    );
   );
 
   add_settings_section(

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -58,7 +58,7 @@ function frontity_embedded_validate_settings( $input ) {
 function frontity_embedded_frontity_server_input() {
   $options = get_option( 'frontity_embedded_plugin_settings' );
   printf(
-    '<input type="text" name="%s" value="%s" style="width: 100%%; max-width: 500px;" />',
+    '<input type="text" name="%s" value="%s" style="width: 100%%; max-width: 500px;">',
     esc_attr( 'frontity_embedded_plugin_settings[frontity_server]' ),
     esc_attr( $options['frontity_server'] )
   );

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -1,0 +1,65 @@
+<?php 
+
+function frontity_embedded_register_menu() {
+  add_options_page(
+    'Frontity Embedded Mode',
+    'Frontity Embedded Mode',
+    'manage_options',
+    'frontity-embedded-plugin',
+    'frontity_embedded_render_admin_page'
+  );
+}
+add_action( 'admin_menu', 'frontity_embedded_register_menu' );
+
+function frontity_embedded_render_admin_page() {
+  ?>
+    <div class="wrap">
+      <h2>Frontity Embedded Mode</h2>  
+      <form method="POST" action="options.php">  
+          <?php 
+              settings_fields( 'frontity_embedded_plugin_settings' );
+              do_settings_sections( 'frontity_embedded_plugin_page' ); 
+          ?>             
+          <?php submit_button(); ?>  
+      </form> 
+    </div>
+  <?php
+}
+
+function frontity_embedded_register_my_setting() {
+  register_setting(
+    'frontity_embedded_plugin_settings',
+    'frontity_embedded_plugin_settings',
+    'frontity_embedded_validate_settings'
+  );
+
+  add_settings_section(
+    'frontity_embedded_plugin_section',
+    '',
+    '__return_empty_string',
+    'frontity_embedded_plugin_page'
+  );
+
+  add_settings_field(
+    'frontity_server',
+    'Frontity Server URL',
+    'frontity_embedded_frontity_server_input',
+    'frontity_embedded_plugin_page',
+    'frontity_embedded_plugin_section'
+  );
+} 
+add_action( 'admin_init', 'frontity_embedded_register_my_setting' );
+
+function frontity_embedded_validate_settings( $input ) {
+  $output['frontity_server'] = esc_url( sanitize_text_field( $input['frontity_server'] ) );
+  return $output;
+}
+
+function frontity_embedded_frontity_server_input() {
+  $options = get_option( 'frontity_embedded_plugin_settings' );
+  printf(
+    '<input type="text" name="%s" value="%s" style="width: 100%%; max-width: 500px;" />',
+    esc_attr( 'frontity_embedded_plugin_settings[frontity_server]' ),
+    esc_attr( $options['frontity_server'] )
+  );
+}

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -26,7 +26,7 @@ function frontity_embedded_render_admin_page() {
   <?php
 }
 
-function frontity_embedded_register_my_setting() {
+function frontity_embedded_register_settings() {
   register_setting(
     'frontity_embedded_plugin_settings',
     'frontity_embedded_plugin_settings',
@@ -48,7 +48,7 @@ function frontity_embedded_register_my_setting() {
     'frontity_embedded_plugin_section'
   );
 } 
-add_action( 'admin_init', 'frontity_embedded_register_my_setting' );
+add_action( 'admin_init', 'frontity_embedded_register_settings' );
 
 function frontity_embedded_validate_settings( $input ) {
   $output['frontity_server'] = esc_url( sanitize_text_field( $input['frontity_server'] ) );

--- a/includes/template.php
+++ b/includes/template.php
@@ -3,7 +3,8 @@
 /**
  * Plugin settings. Edit them to match your Frontity server configuration.
  */
-$frontity_server = 'http://localhost:3000';
+$frontity_settings = get_option( 'frontity_embedded_plugin_settings' );
+$frontity_server = $frontity_settings['frontity_server'];
 
 /**
  * Alternatively, you can use PHP constants or environment variables.


### PR DESCRIPTION
We have added a simple UI for the settings of the plugin. Right now only the "Frontity Server URL" exists.

<img width="804" alt="Screenshot 2021-04-09 at 11 19 25" src="https://user-images.githubusercontent.com/3305402/114160868-ac64e600-9927-11eb-845b-712fdc5bc4ff.png">


We haven't added any description yet. We will ask the DevRels to do so when documenting the plugin in the [Frontity Docs](https://docs.frontity.org).

Co-authored-by: @santosguillamot