### PR TITLE
Feature/add wp head and wp footer do actions

### DIFF
--- a/includes/template.php
+++ b/includes/template.php
@@ -141,20 +141,16 @@ if ( is_wp_error( $response ) ) {
                 $wp_styles->registered['admin-bar']->src,
                 $wp_styles->registered['dashicons']->src
             ];
-            function print_admin_script($script)
-            {
+            function print_admin_script ($script){
                 echo "<script src='" . site_url() . $script . "?ver=" . $wp_version . "'></script>";
-            }
-
-            function print_admin_style($style)
-            {
+            };
+            function print_admin_style ($style){
                 echo "<link rel='stylesheet' href='" . site_url() . $style . "?ver=" . $wp_version . "' />";
-            }
-
-            foreach ($scripts as $script) {
+            };
+            foreach ( $scripts as $script ) {
                 do_action('admin_print_scripts', 'print_admin_script', $script);
             }
-            foreach ($styles as $style) {
+            foreach ( $styles as $style ) {
                 do_action('admin_print_styles', 'print_admin_style', $style);
             }
         }

--- a/includes/template.php
+++ b/includes/template.php
@@ -130,8 +130,18 @@ if ( is_wp_error( $response ) ) {
     */
     do_action('frontity_embedded_wp_head');
 
-    // Get the scripts and styles of the Admin Bar and echo them.
+    // Echo the <body>, but don't echo the </body> tag yet.
+    echo $body;
+
+    /**
+    * Fires a do_action hook similar to wp_footer.
+    * https://developer.wordpress.org/reference/functions/wp_footer/
+    */
+    do_action('frontity_embedded_wp_footer');
+    
+    // Echo the admin bar HTML.
     if (is_admin_bar_showing()) {
+        // Get the scripts and styles of the Admin Bar and echo them.
         $scripts = [
             $wp_scripts->registered['admin-bar']->src,
             $wp_scripts->registered['hoverintent-js']->src
@@ -152,19 +162,6 @@ if ( is_wp_error( $response ) ) {
         foreach ( $styles as $style ) {
             do_action('admin_print_styles', 'print_admin_style', $style);
         }
-    }
-
-    // Echo the <body>, but don't echo the </body> tag yet.
-    echo $body;
-
-    /**
-    * Fires a do_action hook similar to wp_footer.
-    * https://developer.wordpress.org/reference/functions/wp_footer/
-    */
-    do_action('frontity_embedded_wp_footer');
-    
-    // Echo the admin bar HTML.
-    if (is_admin_bar_showing()) {
         _admin_bar_bump_cb();
         wp_admin_bar_header();
         wp_admin_bar_render();

--- a/includes/template.php
+++ b/includes/template.php
@@ -130,6 +130,18 @@ if ( is_wp_error( $response ) ) {
     */
     do_action('frontity_embedded_wp_head');
 
+    if (is_admin_bar_showing()) {
+      $styles = [
+            $wp_styles->registered['admin-bar']->src,
+            $wp_styles->registered['dashicons']->src
+        ];
+      function print_admin_style ($style){
+            echo "<link rel='stylesheet' href='" . site_url() . $style . "?ver=" . $wp_version . "' />";
+        };
+      foreach ( $styles as $style ) {
+            do_action('admin_print_styles', 'print_admin_style', $style);
+        }
+    }
     // Echo the <body>, but don't echo the </body> tag yet.
     echo $body;
 
@@ -146,21 +158,11 @@ if ( is_wp_error( $response ) ) {
             $wp_scripts->registered['admin-bar']->src,
             $wp_scripts->registered['hoverintent-js']->src
         ];
-        $styles = [
-            $wp_styles->registered['admin-bar']->src,
-            $wp_styles->registered['dashicons']->src
-        ];
         function print_admin_script ($script){
             echo "<script src='" . site_url() . $script . "?ver=" . $wp_version . "'></script>";
             };
-        function print_admin_style ($style){
-            echo "<link rel='stylesheet' href='" . site_url() . $style . "?ver=" . $wp_version . "' />";
-        };
         foreach ( $scripts as $script ) {
             do_action('admin_print_scripts', 'print_admin_script', $script);
-        }
-        foreach ( $styles as $style ) {
-            do_action('admin_print_styles', 'print_admin_style', $style);
         }
         _admin_bar_bump_cb();
         wp_admin_bar_header();

--- a/includes/template.php
+++ b/includes/template.php
@@ -8,24 +8,24 @@ $frontity_server = $frontity_settings['frontity_server'];
 
 /**
  * Alternatively, you can use PHP constants or environment variables.
- * 
+ *
  * Note that, if the PHP constant exists, it would take precedence over
  * the corresponding environment variable.
  */
 if ( defined( "FRONTITY_SERVER" ) ) {
-  $frontity_server = FRONTITY_SERVER;
+    $frontity_server = FRONTITY_SERVER;
 } else if ( getenv( "FRONTITY_SERVER" ) ) {
-  $frontity_server = getenv( "FRONTITY_SERVER" );
+    $frontity_server = getenv( "FRONTITY_SERVER" );
 }
 
 /***********************************************************************/
 
 // Redirect Webpack HMR to the Frontity server. Only for development.
 if ( $_SERVER['REQUEST_URI'] === '/__webpack_hmr' ) {
-  header( 'Location: ' . $frontity_server . '/__webpack_hmr' );
-  status_header( 301 );
-  exit();
-} 
+    header( 'Location: ' . $frontity_server . '/__webpack_hmr' );
+    status_header( 301 );
+    exit();
+}
 
 // Build the URL to do the request to the Frontity server.
 $url = untrailingslashit( $frontity_server ) . $_SERVER['REQUEST_URI'];
@@ -39,17 +39,17 @@ $id = get_the_ID();
 // is logged in and can edit the post.
 if ( $id && is_preview() && is_user_logged_in() && current_user_can( 'edit_post', $id ) ) {
 
-  // Generate a token that allows only to preview a specific post or page.
-  $type = get_post_type();
-  $token = Frontity_Embedded_Capability_Tokens::generate( 
-    array(
-      'type'      => 'preview',
-      'post_type' => $type,
-      'post_id'   => $id,
-    )
-  );
+    // Generate a token that allows only to preview a specific post or page.
+    $type = get_post_type();
+    $token = Frontity_Embedded_Capability_Tokens::generate(
+        array(
+            'type'      => 'preview',
+            'post_type' => $type,
+            'post_id'   => $id,
+        )
+    );
 
-  $url = $url . '&frontity_source_auth=Bearer ' . $token;
+    $url = $url . '&frontity_source_auth=Bearer ' . $token;
 }
 
 /**
@@ -76,87 +76,108 @@ $args = apply_filters( 'frontity_embedded_request_args', array( 'timeout' => 30 
 $response = wp_remote_get( $url, $args );
 
 if ( is_wp_error( $response ) ) {
-  // If the request fails, set the status to 500.
-  status_header( 500 );
-  if ( WP_DEBUG === true ) {
-    // If the WordPress is in debug mode, throw an error.
-    throw new Exception( $response->get_error_message() );
-  } else {
-    // If not, send the error page.
-    require_once plugin_dir_path( __FILE__ ) . 'error.php';
-  }
+    // If the request fails, set the status to 500.
+    status_header( 500 );
+    if ( WP_DEBUG === true ) {
+        // If the WordPress is in debug mode, throw an error.
+        throw new Exception( $response->get_error_message() );
+    } else {
+        // If not, send the error page.
+        require_once plugin_dir_path( __FILE__ ) . 'error.php';
+    }
 } else if ( substr( (string) $response[ "response" ][ "code" ], 0, 1 ) === "5" ) {
-  // If the request didn't fail, but Frontity returned an error, set the status
-  // to 500.
-  status_header( 500 );
-  if ( isset( $response[ "headers" ][ "x-frontity-dev" ] ) ) {
-    // If Frontity is in development mode, show the error.
-    echo $response[ "body" ];
-  } else {
-    // If not, send the error page.
-    require_once plugin_dir_path( __FILE__ ) . 'error.php';
-  }
+    // If the request didn't fail, but Frontity returned an error, set the status
+    // to 500.
+    status_header( 500 );
+    if ( isset( $response[ "headers" ][ "x-frontity-dev" ] ) ) {
+        // If Frontity is in development mode, show the error.
+        echo $response[ "body" ];
+    } else {
+        // If not, send the error page.
+        require_once plugin_dir_path( __FILE__ ) . 'error.php';
+    }
 } else {
-  global $wp_query;
+    global $wp_query;
 
-  // Consider static all kind of files Webpack returns as static.
-  $isStatic = preg_match(
-    '/\.(js|png|jpe?g|gif|svg|woff(2)?|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/i',
-    $_SERVER['REQUEST_URI']
-  );
-  
-  // Pass through the Content-Type header.
-  header( 'content-type: ' . $response['headers']['content-type'] );
+    // Consider static all kind of files Webpack returns as static.
+    $isStatic = preg_match(
+        '/\.(js|png|jpe?g|gif|svg|woff(2)?|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/i',
+        $_SERVER['REQUEST_URI']
+    );
 
-  // Pass through the status of the response.
-  status_header( $response['response']['code'] );
+    // Pass through the Content-Type header.
+    header( 'content-type: ' . $response['headers']['content-type'] );
 
-  // Override is_404 of static assets.
-  if ( $isStatic && $response['response']['code'] === 200 )
-    $wp_query->is_404 = false;
-  
-  // Add the Admin Bar.
-  if ( !$isStatic && is_admin_bar_showing() ) {
-    // Divide the HTML to be able to insert things in the <head> and <body>.
-    list($head, $rest) = preg_split('/(?=<\/head>)/', wp_remote_retrieve_body( $response ) );
-    list($body, $end) = preg_split('/(?=<\/body>)/', $rest);
+    // Pass through the status of the response.
+    status_header( $response['response']['code'] );
 
-    // Echo the <head>, but don't echo </head> tag yet. 
-    echo $head;
-  
-    // Get the scripts and styles of the Admin Bar and echo them.
-    $scripts = [
-      $wp_scripts->registered['admin-bar']->src,
-      $wp_scripts->registered['hoverintent-js']->src
-    ];
-    $styles = [
-      $wp_styles->registered['admin-bar']->src,
-      $wp_styles->registered['dashicons']->src
-    ];
-    function print_admin_script ($script){
-      echo "<script src='" . site_url() . $script . "?ver=" . $wp_version . "'></script>";
-    };
-    function print_admin_style ($style){
-      echo "<link rel='stylesheet' href='" . site_url() . $style . "?ver=" . $wp_version . "' />";
-    };
-    foreach ( $scripts as $script ) {
-      do_action('admin_print_scripts', 'print_admin_script', $script);
+    // Override is_404 of static assets.
+    if ( $isStatic && $response['response']['code'] === 200 )
+        $wp_query->is_404 = false;
+
+    // Add Hooks & Admin Bar
+    if (!$isStatic) {
+        // Divide the HTML to be able to insert things in the <head> and <body>.
+        list($head, $rest) = preg_split('/(?=<\/head>)/', wp_remote_retrieve_body( $response ) );
+        list($body, $end) = preg_split('/(?=<\/body>)/', $rest);
+
+        // Echo the <head>, but don't echo </head> tag yet.
+        echo $head;
+
+        /**
+         * Fires a do_action hook similar to wp_head.
+         * https://developer.wordpress.org/reference/functions/wp_head/
+         */
+        do_action('frontity_embedded_wp_head');
+
+        // Add Admin Bar
+        if (is_admin_bar_showing()) {
+            // Get the scripts and styles of the Admin Bar and echo them.
+            $scripts = [
+                $wp_scripts->registered['admin-bar']->src,
+                $wp_scripts->registered['hoverintent-js']->src
+            ];
+            $styles = [
+                $wp_styles->registered['admin-bar']->src,
+                $wp_styles->registered['dashicons']->src
+            ];
+            function print_admin_script($script)
+            {
+                echo "<script src='" . site_url() . $script . "?ver=" . $wp_version . "'></script>";
+            }
+
+            function print_admin_style($style)
+            {
+                echo "<link rel='stylesheet' href='" . site_url() . $style . "?ver=" . $wp_version . "' />";
+            }
+
+            foreach ($scripts as $script) {
+                do_action('admin_print_scripts', 'print_admin_script', $script);
+            }
+            foreach ($styles as $style) {
+                do_action('admin_print_styles', 'print_admin_style', $style);
+            }
+        }
+
+        // Echo the <body>, but don't echo the </body> tag yet.
+        echo $body;
+
+        /**
+         * Fires a do_action hook similar to wp_footer.
+         * https://developer.wordpress.org/reference/functions/wp_footer/
+         */
+        do_action('frontity_embedded_wp_footer');
+
+        // Echo the admin bar HTML.
+        if (is_admin_bar_showing()) {
+            _admin_bar_bump_cb();
+            wp_admin_bar_header();
+            wp_admin_bar_render();
+        }
+
+        // Echo the final </body> and </html> tags.
+        echo $end;
+    } else {
+        echo wp_remote_retrieve_body( $response );
     }
-    foreach ( $styles as $style ) {
-      do_action('admin_print_styles', 'print_admin_style', $style);
-    }
-
-    // Echo the <body>, but don't echo the </body> tag yet.
-    echo $body;
-    
-    // Echo the admin bar HTML.
-    _admin_bar_bump_cb();
-    wp_admin_bar_header();
-    wp_admin_bar_render();
-    
-    // Echo the final </body> and </html> tags.
-    echo $end;
-  } else {
-    echo wp_remote_retrieve_body( $response );
-  }
 } 

--- a/includes/template.php
+++ b/includes/template.php
@@ -8,24 +8,24 @@ $frontity_server = $frontity_settings['frontity_server'];
 
 /**
  * Alternatively, you can use PHP constants or environment variables.
- *
+ * 
  * Note that, if the PHP constant exists, it would take precedence over
  * the corresponding environment variable.
  */
 if ( defined( "FRONTITY_SERVER" ) ) {
-    $frontity_server = FRONTITY_SERVER;
+  $frontity_server = FRONTITY_SERVER;
 } else if ( getenv( "FRONTITY_SERVER" ) ) {
-    $frontity_server = getenv( "FRONTITY_SERVER" );
+  $frontity_server = getenv( "FRONTITY_SERVER" );
 }
 
 /***********************************************************************/
 
 // Redirect Webpack HMR to the Frontity server. Only for development.
 if ( $_SERVER['REQUEST_URI'] === '/__webpack_hmr' ) {
-    header( 'Location: ' . $frontity_server . '/__webpack_hmr' );
-    status_header( 301 );
-    exit();
-}
+  header( 'Location: ' . $frontity_server . '/__webpack_hmr' );
+  status_header( 301 );
+  exit();
+} 
 
 // Build the URL to do the request to the Frontity server.
 $url = untrailingslashit( $frontity_server ) . $_SERVER['REQUEST_URI'];
@@ -39,17 +39,17 @@ $id = get_the_ID();
 // is logged in and can edit the post.
 if ( $id && is_preview() && is_user_logged_in() && current_user_can( 'edit_post', $id ) ) {
 
-    // Generate a token that allows only to preview a specific post or page.
-    $type = get_post_type();
-    $token = Frontity_Embedded_Capability_Tokens::generate(
-        array(
-            'type'      => 'preview',
-            'post_type' => $type,
-            'post_id'   => $id,
-        )
-    );
+  // Generate a token that allows only to preview a specific post or page.
+  $type = get_post_type();
+  $token = Frontity_Embedded_Capability_Tokens::generate( 
+    array(
+      'type'      => 'preview',
+      'post_type' => $type,
+      'post_id'   => $id,
+    )
+  );
 
-    $url = $url . '&frontity_source_auth=Bearer ' . $token;
+  $url = $url . '&frontity_source_auth=Bearer ' . $token;
 }
 
 /**
@@ -76,104 +76,103 @@ $args = apply_filters( 'frontity_embedded_request_args', array( 'timeout' => 30 
 $response = wp_remote_get( $url, $args );
 
 if ( is_wp_error( $response ) ) {
-    // If the request fails, set the status to 500.
-    status_header( 500 );
-    if ( WP_DEBUG === true ) {
-        // If the WordPress is in debug mode, throw an error.
-        throw new Exception( $response->get_error_message() );
-    } else {
-        // If not, send the error page.
-        require_once plugin_dir_path( __FILE__ ) . 'error.php';
-    }
+  // If the request fails, set the status to 500.
+  status_header( 500 );
+  if ( WP_DEBUG === true ) {
+    // If the WordPress is in debug mode, throw an error.
+    throw new Exception( $response->get_error_message() );
+  } else {
+    // If not, send the error page.
+    require_once plugin_dir_path( __FILE__ ) . 'error.php';
+  }
 } else if ( substr( (string) $response[ "response" ][ "code" ], 0, 1 ) === "5" ) {
-    // If the request didn't fail, but Frontity returned an error, set the status
-    // to 500.
-    status_header( 500 );
-    if ( isset( $response[ "headers" ][ "x-frontity-dev" ] ) ) {
-        // If Frontity is in development mode, show the error.
-        echo $response[ "body" ];
-    } else {
-        // If not, send the error page.
-        require_once plugin_dir_path( __FILE__ ) . 'error.php';
-    }
+  // If the request didn't fail, but Frontity returned an error, set the status
+  // to 500.
+  status_header( 500 );
+  if ( isset( $response[ "headers" ][ "x-frontity-dev" ] ) ) {
+    // If Frontity is in development mode, show the error.
+    echo $response[ "body" ];
+  } else {
+    // If not, send the error page.
+    require_once plugin_dir_path( __FILE__ ) . 'error.php';
+  }
 } else {
-    global $wp_query;
+  global $wp_query;
 
-    // Consider static all kind of files Webpack returns as static.
-    $isStatic = preg_match(
-        '/\.(js|png|jpe?g|gif|svg|woff(2)?|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/i',
-        $_SERVER['REQUEST_URI']
-    );
+  // Consider static all kind of files Webpack returns as static.
+  $isStatic = preg_match(
+    '/\.(js|png|jpe?g|gif|svg|woff(2)?|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/i',
+    $_SERVER['REQUEST_URI']
+  );
+  
+  // Pass through the Content-Type header.
+  header( 'content-type: ' . $response['headers']['content-type'] );
 
-    // Pass through the Content-Type header.
-    header( 'content-type: ' . $response['headers']['content-type'] );
+  // Pass through the status of the response.
+  status_header( $response['response']['code'] );
 
-    // Pass through the status of the response.
-    status_header( $response['response']['code'] );
+  // Override is_404 of static assets.
+  if ( $isStatic && $response['response']['code'] === 200 )
+    $wp_query->is_404 = false;
+  
+  // Add the Admin Bar.
+  if ( !$isStatic) {
+    // Divide the HTML to be able to insert things in the <head> and <body>.
+    list($head, $rest) = preg_split('/(?=<\/head>)/', wp_remote_retrieve_body( $response ) );
+    list($body, $end) = preg_split('/(?=<\/body>)/', $rest);
 
-    // Override is_404 of static assets.
-    if ( $isStatic && $response['response']['code'] === 200 )
-        $wp_query->is_404 = false;
+    // Echo the <head>, but don't echo </head> tag yet. 
+    echo $head;
+  
+    /**
+    * Fires a do_action hook similar to wp_head.
+    * https://developer.wordpress.org/reference/functions/wp_head/
+    */
+    do_action('frontity_embedded_wp_head');
 
-    // Add Hooks & Admin Bar
-    if (!$isStatic) {
-        // Divide the HTML to be able to insert things in the <head> and <body>.
-        list($head, $rest) = preg_split('/(?=<\/head>)/', wp_remote_retrieve_body( $response ) );
-        list($body, $end) = preg_split('/(?=<\/body>)/', $rest);
-
-        // Echo the <head>, but don't echo </head> tag yet.
-        echo $head;
-
-        /**
-         * Fires a do_action hook similar to wp_head.
-         * https://developer.wordpress.org/reference/functions/wp_head/
-         */
-        do_action('frontity_embedded_wp_head');
-
-        // Add Admin Bar
-        if (is_admin_bar_showing()) {
-            // Get the scripts and styles of the Admin Bar and echo them.
-            $scripts = [
-                $wp_scripts->registered['admin-bar']->src,
-                $wp_scripts->registered['hoverintent-js']->src
-            ];
-            $styles = [
-                $wp_styles->registered['admin-bar']->src,
-                $wp_styles->registered['dashicons']->src
-            ];
-            function print_admin_script ($script){
-                echo "<script src='" . site_url() . $script . "?ver=" . $wp_version . "'></script>";
+    // Get the scripts and styles of the Admin Bar and echo them.
+    if (is_admin_bar_showing()) {
+        $scripts = [
+            $wp_scripts->registered['admin-bar']->src,
+            $wp_scripts->registered['hoverintent-js']->src
+        ];
+        $styles = [
+            $wp_styles->registered['admin-bar']->src,
+            $wp_styles->registered['dashicons']->src
+        ];
+        function print_admin_script ($script){
+            echo "<script src='" . site_url() . $script . "?ver=" . $wp_version . "'></script>";
             };
-            function print_admin_style ($style){
-                echo "<link rel='stylesheet' href='" . site_url() . $style . "?ver=" . $wp_version . "' />";
-            };
-            foreach ( $scripts as $script ) {
-                do_action('admin_print_scripts', 'print_admin_script', $script);
-            }
-            foreach ( $styles as $style ) {
-                do_action('admin_print_styles', 'print_admin_style', $style);
-            }
+        function print_admin_style ($style){
+            echo "<link rel='stylesheet' href='" . site_url() . $style . "?ver=" . $wp_version . "' />";
+        };
+        foreach ( $scripts as $script ) {
+            do_action('admin_print_scripts', 'print_admin_script', $script);
         }
-
-        // Echo the <body>, but don't echo the </body> tag yet.
-        echo $body;
-
-        /**
-         * Fires a do_action hook similar to wp_footer.
-         * https://developer.wordpress.org/reference/functions/wp_footer/
-         */
-        do_action('frontity_embedded_wp_footer');
-
-        // Echo the admin bar HTML.
-        if (is_admin_bar_showing()) {
-            _admin_bar_bump_cb();
-            wp_admin_bar_header();
-            wp_admin_bar_render();
+        foreach ( $styles as $style ) {
+            do_action('admin_print_styles', 'print_admin_style', $style);
         }
-
-        // Echo the final </body> and </html> tags.
-        echo $end;
-    } else {
-        echo wp_remote_retrieve_body( $response );
     }
+
+    // Echo the <body>, but don't echo the </body> tag yet.
+    echo $body;
+
+    /**
+    * Fires a do_action hook similar to wp_footer.
+    * https://developer.wordpress.org/reference/functions/wp_footer/
+    */
+    do_action('frontity_embedded_wp_footer');
+    
+    // Echo the admin bar HTML.
+    if (is_admin_bar_showing()) {
+        _admin_bar_bump_cb();
+        wp_admin_bar_header();
+        wp_admin_bar_render();
+    }
+    
+    // Echo the final </body> and </html> tags.
+    echo $end;
+  } else {
+    echo wp_remote_retrieve_body( $response );
+  }
 } 


### PR DESCRIPTION
## Description

Fixes #25 

When in embedded mode, adding extra hooks in template.php will allow users to add additional code into the DOM in certain locations. The addition of: `frontity_embedded_wp_head` and `frontity_embedded_wp_footer` hooks will mimic the similar hooks on WordPress:

- https://developer.wordpress.org/reference/functions/wp_head/
- https://developer.wordpress.org/reference/functions/wp_footer/

Use Cases: 
- Adding extra plugins/scripts
- Echo extra `<head>` code or before `</body>` code. 

Notes:
- I thought about using wp_head and wp_footer natively, but it may inject random plugins/code that may not necessarily be desirable given the nature of how we're loading Frontity. A unique separate name seems like the best choice.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
