### PR TITLE
Bypass Elementor-Preview for now

### DIFF
--- a/frontity-embedded.php
+++ b/frontity-embedded.php
@@ -46,7 +46,7 @@ function frontity_embedded_loader() {
   add_filter(
     'template_include',
     function( $template ) {
-      if (!isset($_GET['frontity_bypass']))
+      if (!isset($_GET['frontity_bypass']) && !isset($_GET['elementor-preview']))
         return plugin_dir_path( __FILE__ ) . '/includes/template.php';
       return $template;
     },


### PR DESCRIPTION
Bypass the Frontity-Page for Elementor Preview until there is a better option to edit in Elementor with embedded mode.